### PR TITLE
Fix small bugs in formation of violations

### DIFF
--- a/lib/foodcritic/junit/outputter.rb
+++ b/lib/foodcritic/junit/outputter.rb
@@ -25,7 +25,6 @@ module Foodcritic
 
       def store_violation
         if current_violation
-          puts "current file is now #{current_file_name}, and #{current_violation}"
           violations.push({
             rule: current_violation[:rule],
             message: current_violation[:message],


### PR DESCRIPTION
Currently, the XML outputter fails to address the following scenarios:
1) The last violation is omitted, since previously we only store a violation when we get a new one.
2) When we see a new file source, we should also stop storing this information as part of the violation lines and instead store the current information

Foodcritic versions that I tested with:
- 9.0
- 10.2.2