### PR TITLE
Fix parsing error when FC011 or FC071 are the first exception parsed

### DIFF
--- a/lib/foodcritic/junit/outputter.rb
+++ b/lib/foodcritic/junit/outputter.rb
@@ -38,7 +38,7 @@ module Foodcritic
         input.each_line do |line|
           line.chomp!
 
-          if File.exist?(line)
+          if File.exist?(line) || %w(README.md LICENSE).include?(line)
             store_violation
             @current_violation = nil
             @current_violation_lines = []

--- a/lib/foodcritic/junit/version.rb
+++ b/lib/foodcritic/junit/version.rb
@@ -1,5 +1,5 @@
 module Foodcritic
   module Junit
-    VERSION = "0.2.2"
+    VERSION = "0.2.3"
   end
 end

--- a/spec/foodcritic/junit_spec.rb
+++ b/spec/foodcritic/junit_spec.rb
@@ -3,15 +3,35 @@ module Foodcritic
   module Junit
     describe Foodcritic::Junit do
       let(:success_msg) { /Wrote test\/reports\/foodcritic-report.xml/ }
-      let(:violations_input) { seed_dir.join('foodcritic-input-violations.txt').read }
-      let(:violations_outputter) { Outputter.new(violations_input) }
-
       it "has a version number" do
         expect(Foodcritic::Junit::VERSION).not_to be nil
       end
 
-      it 'builds a report for foodcritic violations' do
-        expect { violations_outputter.run }.to output(success_msg).to_stderr_from_any_process
+      context 'with existing files for all violations' do
+        let(:violations_input) { seed_dir.join('foodcritic-input-violations.txt').read }
+        let(:violations_outputter) { Outputter.new(violations_input) }
+
+        it 'builds a report for foodcritic violations' do
+          expect { violations_outputter.run }.to output(success_msg).to_stderr_from_any_process
+        end
+      end
+
+      context 'with missing files for first violation' do
+        before do
+          # Stub out File.exist? for README.md and LICENSE so we do not get the
+          # ones from the foodcritic-junit gem
+          allow(File).to receive(:exist?).and_call_original
+          %w(README.md LICENSE).each do |file|
+            allow(File).to receive(:exist?).with(file).and_return(false)
+          end
+        end
+
+        let(:violations_input) { seed_dir.join('foodcritic-input-missing-violations.txt').read }
+        let(:violations_outputter) { Outputter.new(violations_input) }
+
+        it 'builds a report for foodcritic violations' do
+          expect { violations_outputter.run }.to output(success_msg).to_stderr_from_any_process
+        end
       end
     end
   end

--- a/spec/seed/foodcritic-input-missing-violations.txt
+++ b/spec/seed/foodcritic-input-missing-violations.txt
@@ -1,0 +1,4 @@
+LICENSE
+FC071: Missing LICENSE file
+README.md
+FC011: Missing README in markdown format


### PR DESCRIPTION
@thomasv314 This pull requests fixes parsing errors when either FC011 or FC071 are the first exception encountered. This occurs because the parser is expecting any files mentioned by foodcritic to exist while these errors indicate that the file is missing.

Here is a quick example of the problem:

Example output from foodcritic:
```
Checking 2 files
x.
LICENSE
FC071: Missing LICENSE file
metadata.rb
FC069: Ensure standardized license defined in metadata
FC078: Ensure cookbook shared under an OSI-approved open source license
   1|name 'my_rad_cookbook'
   2|maintainer 'John Smith'
   3|maintainer_email 'john.smith@email.com'
   4|license 'all_rights'
```

Error from foodcritic-junit upon parsing:
```
/my/ruby/path/ruby-2.3.3/gems/foodcritic-junit-0.2.2/lib/foodcritic/junit/outputter.rb:93:in `xml_for_violation': undefined method `encode' for nil:NilClass (NoMethodError)
        from /home/jenkins/.rvm/gems/ruby-2.3.3/gems/foodcritic-junit-0.2.2/lib/foodcritic/junit/outputter.rb:85:in `block in violations_as_xml'
        from /home/jenkins/.rvm/gems/ruby-2.3.3/gems/foodcritic-junit-0.2.2/lib/foodcritic/junit/outputter.rb:85:in `map'
        from /home/jenkins/.rvm/gems/ruby-2.3.3/gems/foodcritic-junit-0.2.2/lib/foodcritic/junit/outputter.rb:85:in `violations_as_xml'
        from /home/jenkins/.rvm/gems/ruby-2.3.3/gems/foodcritic-junit-0.2.2/lib/foodcritic/junit/outputter.rb:77:in `xml'
        from /home/jenkins/.rvm/gems/ruby-2.3.3/gems/foodcritic-junit-0.2.2/lib/foodcritic/junit/outputter.rb:68:in `block in write_output'
        from /home/jenkins/.rvm/gems/ruby-2.3.3/gems/foodcritic-junit-0.2.2/lib/foodcritic/junit/outputter.rb:68:in `open'
        from /home/jenkins/.rvm/gems/ruby-2.3.3/gems/foodcritic-junit-0.2.2/lib/foodcritic/junit/outputter.rb:68:in `write_output'
        from /home/jenkins/.rvm/gems/ruby-2.3.3/gems/foodcritic-junit-0.2.2/lib/foodcritic/junit/outputter.rb:23:in `run'
        from /home/jenkins/.rvm/gems/ruby-2.3.3/gems/foodcritic-junit-0.2.2/bin/foodcritic-junit:5:in `<top (required)>'
        from /home/jenkins/.rvm/gems/ruby-2.3.3/bin/foodcritic-junit:22:in `load'
        from /home/jenkins/.rvm/gems/ruby-2.3.3/bin/foodcritic-junit:22:in `<main>'
        from /home/jenkins/.rvm/gems/ruby-2.3.3/bin/ruby_executable_hooks:15:in `eval'
        from /home/jenkins/.rvm/gems/ruby-2.3.3/bin/ruby_executable_hooks:15:in `<main>'
```

Please let me know if you require any changes to merge this pull request. A new test has been added to cover this issue.